### PR TITLE
feat(pg_id): get runtime pg_role, declare new variables pg_role_runtime, pg_role_config

### DIFF
--- a/roles/pg_id/tasks/main.yml
+++ b/roles/pg_id/tasks/main.yml
@@ -8,6 +8,19 @@
 - name: pgsql identity
   tags: [always, pg-id ]
   block:
+    - name: run pg-role
+      command: /pg/bin/pg-role
+      register: pg_role_cmd
+
+    - name: set variable pg_role_config, pg_role_runtime
+      set_fact:
+        pg_role_config: "{{ pg_role }}"
+        # if pg_role_cmd.stdout is not defined, use pg_role as default
+        pg_role_runtime: "{{ pg_role_cmd.stdout | default(pg_role) | trim }}"
+
+    - name: reset variable pg_role by pg_role_runtime
+      set_fact:
+        pg_role: "{{ pg_role_runtime }}"
 
     - name: get pgsql identity
       connection: local


### PR DESCRIPTION
assign pg_role_runtime value to pg_role, prevent wrong pg_role value after patroni switchover
