### PR TITLE
cloudflare dns challenge

### DIFF
--- a/roles/infra/tasks/nginx.yml
+++ b/roles/infra/tasks/nginx.yml
@@ -38,6 +38,17 @@
         upstrema_conf: '{% if "conf" in item.value %}{{ item.value.conf }}{% elif item.key == "home" %}home.conf{% elif "path" in item.value %}path.conf{% elif "endpoint" in item.value %}endpoint.conf{% endif %}'
       with_dict: "{{ infra_portal|default({}) }}"
 
+- name: Create Cloudflare credentials file for Certbot
+  copy:
+    dest: /etc/nginx/conf.d/cert/cloudflare.ini
+    content: |
+      # Cloudflare API token used by Certbot
+      dns_cloudflare_api_token = {{ dns_cloudflare_api_token }}
+    owner: root
+    group: root
+    mode: '0600'
+  when: dns_cloudflare_api_token is defined and dns_cloudflare_api_token != ''
+  become: yes # Ensure file is created as root
 
 #--------------------------------------------------------------#
 # 2. Nginx Cert                                     [nginx_cert]
@@ -183,6 +194,7 @@
   when: certbot_sign is defined and certbot_sign|bool
   ignore_errors: true
   command: /etc/nginx/sign-cert
+  run_once: true
 
 - name: reload nginx service
   tags: nginx_reload

--- a/roles/infra/templates/nginx/sign-cert.j2
+++ b/roles/infra/templates/nginx/sign-cert.j2
@@ -13,6 +13,8 @@ set -euo pipefail
 EMAIL="{{ certbot_email     | default('your@email.com') }}"
 WEBROOT="{{ nginx_home|default('/www') + '/acme' }}"
 OPTIONS=${1-"{{ certbot_options | default('') }}"}
+CLOUDFLARE_CREDENTIALS_FILE="/etc/nginx/conf.d/cert/cloudflare.ini"
+
 {% set certbot_map = {} %}
 {% for name, item in infra_portal.items() %}
   {% if item.certbot is defined and item.certbot %}
@@ -45,16 +47,34 @@ echo "issue {{ cert_name }} : {{ domains|join(', ') }}"
 
 if [ -f "/etc/letsencrypt/renewal/{{ cert_name }}.conf" ]; then
     echo "  -> Certificate exists. Attempting to expand/renew if needed..."
-    certbot certonly --non-interactive --cert-name {{ cert_name }} \
-        --webroot --webroot-path="$WEBROOT" \
-        --email "$EMAIL" --agree-tos --no-eff-email --expand \
-        {% for domain in domains %}-d "{{ domain }}" {% endfor %} $OPTIONS
+    if [ -f "$CLOUDFLARE_CREDENTIALS_FILE" ]; then  # Check if the file exists
+        echo "  -> Using Cloudflare DNS challenge."
+        certbot certonly --non-interactive --cert-name {{ cert_name }} \
+            --dns-cloudflare --dns-cloudflare-credentials "$CLOUDFLARE_CREDENTIALS_FILE" --dns-cloudflare-propagation-seconds 30 \
+            --email "$EMAIL" --agree-tos --no-eff-email --expand \
+            {% for domain in domains %}-d "{{ domain }}" {% endfor %} $OPTIONS
+    else
+        echo "  -> Using Webroot challenge."
+        certbot certonly --non-interactive --cert-name {{ cert_name }} \
+            --webroot --webroot-path="$WEBROOT" \
+            --email "$EMAIL" --agree-tos --no-eff-email --expand \
+            {% for domain in domains %}-d "{{ domain }}" {% endfor %} $OPTIONS
+    fi
 else
     echo "  -> Certificate does not exist. Obtaining a new certificate..."
-    certbot certonly --non-interactive --cert-name {{ cert_name }} \
-        --webroot --webroot-path="$WEBROOT" \
-        --email "$EMAIL" --agree-tos --no-eff-email \
-        {% for domain in domains %}-d "{{ domain }}" {% endfor %} $OPTIONS
+    if [ -f "$CLOUDFLARE_CREDENTIALS_FILE" ]; then # Check if the file exists
+        echo "  -> Using Cloudflare DNS challenge."
+        certbot certonly --non-interactive --cert-name {{ cert_name }} \
+            --dns-cloudflare --dns-cloudflare-credentials "$CLOUDFLARE_CREDENTIALS_FILE" --dns-cloudflare-propagation-seconds 30 \
+            --email "$EMAIL" --agree-tos --no-eff-email \
+            {% for domain in domains %}-d "{{ domain }}" {% endfor %} $OPTIONS
+    else
+        echo "  -> Using Webroot challenge."
+        certbot certonly --non-interactive --cert-name {{ cert_name }} \
+            --webroot --webroot-path="$WEBROOT" \
+            --email "$EMAIL" --agree-tos --no-eff-email \
+            {% for domain in domains %}-d "{{ domain }}" {% endfor %} $OPTIONS
+    fi
 fi
 
 echo "  -> Done for {{ cert_name }}: {{ domains|join(', ') }}"


### PR DESCRIPTION
Just in case you'd find it useful, I'm a big fan of using Cloudflare's DNS challenge to easily generate trusted certs when using private IP addresses.

I wired this in using the commit below, and three additional variables in my `pigsty.yml`:

```
    dns_cloudflare_api_token: "{{ lookup('env', 'DNS_CLOUDFLARE_API_TOKEN') }}"
    repo_packages: "{{ repo_packages_default + ['python3-certbot-dns-cloudflare'] }}"
    infra_packages: "{{ infra_packages_default + ['python3-certbot-dns-cloudflare'] }}"
```

The only caveat is that you really don't want this running on multiple nodes simultaneously... so I added "run_once" to the sign-cert operation. It needs to be serialized so you don't have multiple nodes modifying DNS records at the same time.

Thanks again!