### PR TITLE
Default extensions schema

### DIFF
--- a/roles/pgsql/defaults/main.yml
+++ b/roles/pgsql/defaults/main.yml
@@ -123,7 +123,7 @@ pg_default_privileges:            # default privileges when created by admin use
   - GRANT REFERENCES ON TABLES    TO dbrole_admin
   - GRANT TRIGGER    ON TABLES    TO dbrole_admin
   - GRANT CREATE     ON SCHEMAS   TO dbrole_admin
-pg_default_schemas: [ monitor ]   # default schemas to be created
+pg_default_schemas: [ monitor, extensions ]   # default schemas to be created
 pg_default_extensions:            # default extensions to be created
   - { name: pg_stat_statements ,schema: monitor }
   - { name: pgstattuple        ,schema: monitor }
@@ -132,14 +132,14 @@ pg_default_extensions:            # default extensions to be created
   - { name: pg_prewarm         ,schema: monitor }
   - { name: pg_visibility      ,schema: monitor }
   - { name: pg_freespacemap    ,schema: monitor }
-  - { name: postgres_fdw       ,schema: public  }
-  - { name: file_fdw           ,schema: public  }
-  - { name: btree_gist         ,schema: public  }
-  - { name: btree_gin          ,schema: public  }
-  - { name: pg_trgm            ,schema: public  }
-  - { name: intagg             ,schema: public  }
-  - { name: intarray           ,schema: public  }
-  - { name: pg_repack }
+  - { name: postgres_fdw       ,schema: extensions  }
+  - { name: file_fdw           ,schema: extensions  }
+  - { name: btree_gist         ,schema: extensions  }
+  - { name: btree_gin          ,schema: extensions  }
+  - { name: pg_trgm            ,schema: extensions  }
+  - { name: intagg             ,schema: extensions  }
+  - { name: intarray           ,schema: extensions  }
+  - { name: pg_repack          ,schema: extensions  }
 pg_reload: true                   # reload postgres/pgbouncer/vip after conf changes
 pg_default_hba_rules:             # postgres default host-based authentication rules
   - {user: '${dbsu}'    ,db: all         ,addr: local     ,auth: ident ,title: 'dbsu access via local os user ident'  }

--- a/roles/pgsql/templates/pg-db.sql
+++ b/roles/pgsql/templates/pg-db.sql
@@ -79,6 +79,9 @@ COMMENT ON DATABASE "{{ database.name }}" IS '{{ database.comment }}';
 COMMENT ON DATABASE "{{ database.name }}" IS 'business database {{ database.name }}';
 {% endif %}
 
+-- search path
+ALTER DATABASE "{{ database.name }}" SET search_path = "$user", public, extensions;
+
 
 --==================================================================--
 --                       REVOKE/GRANT CONNECT                       --


### PR DESCRIPTION
Small suggestion / question -- in alignment with security best practices, would it make sense to consistently add an `extensions` schema alongside the default `monitoring` schema to avoid installing extensions in `public`?

I then updated the default search_path as well.