### PR TITLE
Expose monitor schema to Supabase admin

### DIFF
--- a/files/supabase.sql
+++ b/files/supabase.sql
@@ -118,7 +118,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authentic
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
 
-ALTER USER supabase_admin SET search_path TO public, extensions;
+ALTER USER supabase_admin SET search_path TO public, extensions, monitor;
 ALTER DEFAULT PRIVILEGES FOR USER supabase_admin IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES FOR USER supabase_admin IN SCHEMA public GRANT ALL ON FUNCTIONS TO anon, authenticated, service_role;
 ALTER DEFAULT PRIVILEGES FOR USER supabase_admin IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary
- keep pg_stat_statements in Pigsty's monitor schema for pg_exporter compatibility
- add monitor to the supabase_admin search_path in the Supabase baseline SQL

## Reason
The Supabase docker compose in this repo runs postgres-meta with PG_META_DB_USER=supabase_admin, and Studio calls postgres-meta for dashboard database features. Supabase Query Performance uses unqualified pg_stat_statements queries, while Pigsty creates pg_stat_statements in the monitor schema for its PostgreSQL monitoring stack. Adding monitor to supabase_admin's search_path lets Supabase Query Performance find pg_stat_statements without moving the extension away from the schema expected by pg_exporter.

## Tests
- Parsed conf/supabase.yml with Ruby YAML loader.
- Not run; configuration/baseline SQL change only.