### PR TITLE
fix(conf): declare MinIO users in ha/trio template

### DIFF
--- a/conf/ha/trio.yml
+++ b/conf/ha/trio.yml
@@ -37,7 +37,12 @@ all:  # top level object
 
     minio: # minio cluster, s3 compatible object storage
       hosts: { 10.10.10.10: { minio_seq: 1 } }
-      vars: { minio_cluster: minio }
+      vars:
+        minio_cluster: minio
+        minio_users:
+          - { access_key: pgbackrest  ,secret_key: S3User.Backup ,policy: pgsql }
+          - { access_key: s3user_meta ,secret_key: S3User.Meta   ,policy: meta  }
+          - { access_key: s3user_data ,secret_key: S3User.Data   ,policy: data  }
 
     pg-meta:  # 3 instance postgres cluster `pg-meta`
       hosts:  # pg-meta-3 is marked as offline readable replica


### PR DESCRIPTION
The ha/trio template enables MinIO as the pgBackRest repository but does not declare minio_users. When configure -g is used, the S3User.Backup value in pgbackrest_repo is randomized while the MinIO user continues to inherit the default secret from the role.

Declare the default MinIO users explicitly so generated credentials remain consistent.


## Problem

The `ha/trio` template deploys MinIO and enables it as the pgBackRest
repository, but it does not explicitly declare `minio_users`.

When generating the configuration with:

```bash
./configure -c ha/trio -g -s
```

`configure -g` replaces `S3User.Backup` in:

```yaml
pgbackrest_repo.minio.s3_key_secret
```

However, `minio_users` is absent from the generated configuration, so
the MinIO role continues to use its default `S3User.Backup` secret.

This results in different credentials being used by MinIO and
pgBackRest, causing:

```text
HTTP 403 Forbidden
SignatureDoesNotMatch
```

during `pgbackrest stanza-create`.

## Root cause

Password generation performs string replacement only on values present
in the selected configuration template. The `ha/trio` template contains
the pgBackRest S3 secret but not the corresponding MinIO user definition.

## Fix

Explicitly declare the standard MinIO users in the `ha/trio` template,
following the same pattern used by other templates that enable MinIO
backups.

This allows `configure -g` to replace both the MinIO user secret and the
pgBackRest S3 secret with the same generated value.


